### PR TITLE
fix: made the transactions history container scrollable 

### DIFF
--- a/src/components/Transactions.js
+++ b/src/components/Transactions.js
@@ -6,7 +6,7 @@ const Transactions = ({transactions}) =>{
         <Box>
                <Typography variant="h5"> Transaction History </Typography> 
                <Divider/>
-               <List>
+               <List style={{maxHeight: '65vh', overflow: 'auto'}} >
                 {
                     transactions.map(transaction => (
                             <Transaction transaction={transaction}/>


### PR DESCRIPTION
fixes #7 

On adding more transactions, now the items won't overflow out of container.

![scroll](https://github.com/Google-DSC-DMCE/Expense-Tracker-HacktoberFest-2023/assets/114895266/b9f834a7-fc6d-40f0-ac35-f9e98891594c)
